### PR TITLE
PLAT-41638 Fix jar filename mismatch

### DIFF
--- a/module/dist-assembly.xml
+++ b/module/dist-assembly.xml
@@ -20,6 +20,10 @@
       <filtered>true</filtered>
       <outputDirectory>${file.separator}</outputDirectory>
     </file>
+    <file>
+      <source>${project.build.directory}/${project.build.finalName}.${project.packaging}</source>
+      <outputDirectory>lib</outputDirectory>
+    </file>
   </files>
   <dependencySets>
     <dependencySet>
@@ -27,6 +31,7 @@
       <excludes>
         <exclude>com.attivio.searchui:frontend:zip:dist</exclude>
       </excludes>
+      <useProjectArtifact>false</useProjectArtifact>
     </dependencySet>
     <dependencySet>
       <outputDirectory>webapps/searchui/dist</outputDirectory>

--- a/module/pom.xml
+++ b/module/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>parent</artifactId>
     <version>1.0.2-SNAPSHOT</version>
   </parent>
-  <artifactId>searchui-module</artifactId>
+  <artifactId>module</artifactId>
   <name>Module</name>
   <description>Wraps the front-end application in an Attivio module</description>
   <dependencies>
@@ -39,6 +39,7 @@
     </dependency>
   </dependencies>
   <build>
+    <finalName>searchui-module-${project.version}</finalName>
     <resources>
       <resource>
         <directory>src/main/resources</directory>


### PR DESCRIPTION
The assembly plugin doesn't respect the `finalName` property when creating the zip.

Modified the descriptor to exclude the generated module jar from the `dependencySet` (via `useProjectArtifact` :arrow_right:  `false`) and instead explicitly include the correctly-named jar in the assembly using an additional `file` element.

