### PR TITLE
PLAT-40591: Add styling for non-clickable tag clouds

### DIFF
--- a/frontend/src/style/bootstrap/attivio-search-results.less
+++ b/frontend/src/style/bootstrap/attivio-search-results.less
@@ -696,6 +696,10 @@
 	padding: 0.4375rem;
 	transition: all .2s ease-in-out;
 }
+.attivio-cloud li:hover.attivio-cloud-noLink,
+.attivio-cloud li:focus.attivio-cloud-noLink {
+    transform:scale(1);
+}
 .attivio-cloud li:hover,
 .attivio-cloud li:focus {
     transform:scale(1.1);


### PR DESCRIPTION
[PLAT-40591](https://jira.attivio.com/browse/PLAT-40591) : When a facet is applied, that facet should not be rendered.

Add styling for tag clouds that have `noLink=true`, that is, tags that are not clickable. These tags are in plain text and this styling would prevent them from scaling on hover. A new CSS class `attivio-cloud-noLink` is created for this styling in suit - https://github.com/attivio/suit/pull/152.