### PR TITLE
fix: add double quote to Webpack output path argument

### DIFF
--- a/frontend/pom.xml
+++ b/frontend/pom.xml
@@ -46,7 +46,7 @@
               <goal>webpack</goal>
             </goals>
             <configuration>
-              <arguments>--output-path=${project.build.directory}/dist</arguments>
+              <arguments>--output-path="${project.build.directory}/dist"</arguments>
             </configuration>
           </execution>
           <execution>


### PR DESCRIPTION
It adds a double quote to avoid an error with whitespaces in the path.
Example of  the path: `C:\My projects\searchui`