### PR TITLE
feat/PLAT-44338 : Add /no-mast url to searchui to not render mast for admin 2.0

### DIFF
--- a/frontend/src/SearchUIApp.js
+++ b/frontend/src/SearchUIApp.js
@@ -73,6 +73,10 @@ export default class SearchUIApp extends React.Component<void, {}, SearchUIAppSt
     '/doc360',
     '/locallogin',
     '/error',
+    '/no-mast',
+    '/no-mast-results',
+    '/no-mast-insights',
+    '/no-mast-doc360',
   ];
 
   /**
@@ -200,9 +204,10 @@ export default class SearchUIApp extends React.Component<void, {}, SearchUIAppSt
     if (this.state.config.searchEngineTypen && this.state.config.searchEngineType !== 'attivio') {
       return [];
     }
+    const noMast = window.location.pathname.includes('no-mast');
     return [
-      new MastheadNavTabs.NavTabInfo('Results', '/results'),
-      new MastheadNavTabs.NavTabInfo('Insights', '/insights'),
+      new MastheadNavTabs.NavTabInfo('Results', noMast ? '/no-mast-results' : '/results'),
+      new MastheadNavTabs.NavTabInfo('Insights', noMast ? '/no-mast-insights' : '/insights'),
     ];
   }
 
@@ -275,8 +280,11 @@ export default class SearchUIApp extends React.Component<void, {}, SearchUIAppSt
                 <AuthRoute exact path="/no-mast" component={SearchUILandingPage} />
                 <AuthRoute exact path="/landing" component={SearchUIFakeLandingPage} />
                 <AuthRoute exact path="/results" component={SearchUISearchPage} />
+                <AuthRoute exact path="/no-mast-results" component={SearchUISearchPage} />
                 <AuthRoute exact path="/insights" component={SearchUIInsightsPage} />
+                <AuthRoute exact path="/no-mast-insights" component={SearchUIInsightsPage} />
                 <AuthRoute exact path="/doc360" component={Document360Page} />
+                <AuthRoute exact path="/no-mast-doc360" component={Document360Page} />
                 <Route exact path="/locallogin" component={LoginPage} />
                 <Route exact path="/error" component={SearchUIErrorPage} />
                 <Route path="*" component={SearchUIErrorPage} />

--- a/frontend/src/SearchUIApp.js
+++ b/frontend/src/SearchUIApp.js
@@ -272,6 +272,7 @@ export default class SearchUIApp extends React.Component<void, {}, SearchUIAppSt
             <Searcher>
               <Switch>
                 <AuthRoute exact path="/" component={SearchUILandingPage} />
+                <AuthRoute exact path="/no-mast" component={SearchUILandingPage} />
                 <AuthRoute exact path="/landing" component={SearchUIFakeLandingPage} />
                 <AuthRoute exact path="/results" component={SearchUISearchPage} />
                 <AuthRoute exact path="/insights" component={SearchUIInsightsPage} />

--- a/frontend/src/pages/Document360Page.js
+++ b/frontend/src/pages/Document360Page.js
@@ -283,6 +283,7 @@ class Document360Page extends React.Component<Document360PageDefaultProps, Docum
 
   render() {
     let pageContents;
+    const simple = this.props.location && this.props.location.pathname.includes('no-mast');
 
     if (this.state.doc) {
       const doc = this.state.doc;
@@ -342,7 +343,7 @@ class Document360Page extends React.Component<Document360PageDefaultProps, Docum
 
     return (
       <div>
-        <Masthead multiline homeRoute="/landing" logoutFunction={AuthUtils.logout}>
+        <Masthead multiline simple={simple} homeRoute="/landing" logoutFunction={AuthUtils.logout}>
           <MastheadNavTabs tabInfo={this.context.app.getMastheadNavTabs()} />
           <SearchBar
             inMasthead

--- a/frontend/src/pages/Document360Page.js
+++ b/frontend/src/pages/Document360Page.js
@@ -347,11 +347,11 @@ class Document360Page extends React.Component<Document360PageDefaultProps, Docum
           <MastheadNavTabs tabInfo={this.context.app.getMastheadNavTabs()} />
           <SearchBar
             inMasthead
-            route="/results"
+            route={simple ? '/no-mast-results' : '/results'}
           />
         </Masthead>
         <SecondaryNavBar>
-          <Doc360Breadcrumbs currentDoc={this.state.doc} />
+          <Doc360Breadcrumbs currentDoc={this.state.doc} urlResultsPage={simple ? '/no-mast-results' : '/results'} />
         </SecondaryNavBar>
         <div style={{ padding: '10px' }}>
           {pageContents}

--- a/frontend/src/pages/SearchUIInsightsPage.js
+++ b/frontend/src/pages/SearchUIInsightsPage.js
@@ -17,6 +17,7 @@ import {
 import SearchUIApp from '../SearchUIApp';
 
 type SearchUIInsightsPageProps = {
+  location: PropTypes.object.isRequired;
   /** The facet field names that should be displayed as pie charts */
   pieChartFacets: Array<string> | string | null;
   /** The facet field names that should be displayed as bar charts */
@@ -49,6 +50,7 @@ class SearchUIInsightsPage extends React.Component<SearchUIInsightsPageProps, Se
   };
 
   static defaultProps = {
+    location: null,
     pieChartFacets: null,
     barChartFacets: null,
     columnChartFacets: null,
@@ -62,9 +64,10 @@ class SearchUIInsightsPage extends React.Component<SearchUIInsightsPageProps, Se
   };
 
   render() {
+    const simple = this.props.location && this.props.location.pathname.includes('/no-mast');
     return (
       <div>
-        <Masthead multiline homeRoute="/landing" logoutFunction={AuthUtils.logout}>
+        <Masthead multiline simple={simple} homeRoute="/landing" logoutFunction={AuthUtils.logout}>
           <MastheadNavTabs initialTab="/insights" tabInfo={this.context.app.getMastheadNavTabs()} />
           <SearchBar
             inMasthead

--- a/frontend/src/pages/SearchUILandingPage.js
+++ b/frontend/src/pages/SearchUILandingPage.js
@@ -18,6 +18,7 @@ import {
 import SearchUIApp from '../SearchUIApp';
 
 type SearchUILandingPageProps = {
+  location: PropTypes.object.isRequired;
   logoUri: string | null;
   logoWidth: string | null;
   logoHeight: string | null;
@@ -144,9 +145,11 @@ class SearchUILandingPage extends React.Component<SearchUILandingPageDefaultProp
       logoStyle.height = this.props.logoHeight;
     }
 
+    const simple = this.props.location && this.props.location.pathname.includes('/no-mast');
+
     return (
       <div>
-        <Masthead multiline homeRoute="/landing" logoutFunction={AuthUtils.logout}>
+        <Masthead multiline simple={simple} homeRoute="/landing" logoutFunction={AuthUtils.logout}>
           <MastheadNavTabs initialTab="/" tabInfo={this.context.app.getMastheadNavTabs()} />
         </Masthead>
         <Grid>
@@ -165,7 +168,7 @@ class SearchUILandingPage extends React.Component<SearchUILandingPageDefaultProp
                 <div style={{ display: 'inline-block', width: '50%' }}>
                   <SearchBar
                     allowLanguageSelect={false}
-                    route="/results"
+                    route={simple ? '/no-mast-results' : '/results'}
                   />
                 </div>
               </div>

--- a/frontend/src/pages/SearchUISearchPage.js
+++ b/frontend/src/pages/SearchUISearchPage.js
@@ -28,6 +28,7 @@ import {
 import SearchUIApp from '../SearchUIApp';
 
 type SearchUISearchPageProps = {
+  location: PropTypes.object.isRequired;
   /**
    * Optional. The location of the node through which to interact with Attivio.
    * Defaults to the value in the configuration.
@@ -104,6 +105,7 @@ type SearchUISearchPageProps = {
  */
 class SearchUISearchPage extends React.Component<SearchUISearchPageProps, SearchUISearchPageProps, void> {
   static defaultProps = {
+    location: null,
     baseUri: '',
     searchEngineType: 'attivio',
     relevancyModels: [],
@@ -167,9 +169,10 @@ class SearchUISearchPage extends React.Component<SearchUISearchPageProps, Search
   render() {
     const showScores = this.props.showScores && this.props.searchEngineType === 'attivio';
     const showTags = this.props.searchEngineType === 'attivio';
+    const simple = this.props.location && this.props.location.pathname.includes('no-mast');
     return (
       <div>
-        <Masthead multiline homeRoute="/landing" logoutFunction={AuthUtils.logout}>
+        <Masthead multiline simple={simple} homeRoute="/landing" logoutFunction={AuthUtils.logout}>
           <MastheadNavTabs initialTab="/results" tabInfo={this.context.app.getMastheadNavTabs()} />
           <SearchBar
             inMasthead

--- a/frontend/src/pages/SearchUISearchPage.js
+++ b/frontend/src/pages/SearchUISearchPage.js
@@ -206,6 +206,7 @@ class SearchUISearchPage extends React.Component<SearchUISearchPageProps, Search
                   baseUri={this.props.baseUri}
                   showScores={showScores}
                   showTags={showTags}
+                  url360Page={simple ? '/no-mast-doc360' : '/doc360'}
                 />
               </Col>
             </Row>

--- a/module/src/main/resources/webapps/searchui/WEB-INF/searchui-servlet.xml
+++ b/module/src/main/resources/webapps/searchui/WEB-INF/searchui-servlet.xml
@@ -23,6 +23,7 @@
     the default index page or users will see a 404 error when navigating directly to them.
   -->
   <mvc:view-controller path="/" view-name="index" />
+  <mvc:view-controller path="/no-mast" view-name="index" />
   <mvc:view-controller path="landing" view-name="index" />
   <mvc:view-controller path="/results" view-name="index" />
   <mvc:view-controller path="/insights" view-name="index" />

--- a/module/src/main/resources/webapps/searchui/WEB-INF/searchui-servlet.xml
+++ b/module/src/main/resources/webapps/searchui/WEB-INF/searchui-servlet.xml
@@ -26,8 +26,11 @@
   <mvc:view-controller path="/no-mast" view-name="index" />
   <mvc:view-controller path="landing" view-name="index" />
   <mvc:view-controller path="/results" view-name="index" />
+  <mvc:view-controller path="/no-mast-results" view-name="index" />
   <mvc:view-controller path="/insights" view-name="index" />
+  <mvc:view-controller path="/no-mast-insights" view-name="index" />
   <mvc:view-controller path="/doc360" view-name="index" />
+  <mvc:view-controller path="/no-mast-doc360" view-name="index" />
   <mvc:view-controller path="login" view-name="index" />
   <mvc:view-controller path="/loggedout" view-name="index" />
   <mvc:view-controller path="/error" view-name="index" />


### PR DESCRIPTION
[PLAT-44338](https://jira.attivio.com/browse/PLAT-44338): Clicking Search should render SearchUI

Dependent on:
- [x]  https://github.com/attivio/suit/pull/158
- [ ]  https://github.com/attivio/suit/pull/160

Admin 2.0 requires Search UI to be rendered without the Attivio logo, application name and the logged in user info in the mast, when `/no-mast` path is included in the url.

Based on https://github.com/attivio/suit/pull/158, `<Masthead>` in suit will render a minimal view of the mast, if the URL contains `/no-mast`. Thus, `/no-mast` URL is simply allowed in searchui.