### PR TITLE
chore/PLAT-40591: Bump up attivio/suit to version 1.0.6

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@attivio/suit": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@attivio/suit/-/suit-1.0.5.tgz",
-      "integrity": "sha512-G0dPJzq6V0GdKWD+tZGjwFuPoQpAesAP5FqrREq7Sa4BYCu1fqMB6NVN/cVsQStMiJIk2yTf6ok5VvYSe8KauA==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@attivio/suit/-/suit-1.0.6.tgz",
+      "integrity": "sha512-Whda+3WENxwvOOG9V6egX6GrmJyRPRS2vK9/RT0IRfqnSvs1lSXv3kio4Lzb6FDAhHltb0TruX4ltW98P4sF1Q==",
       "requires": {
         "@mapbox/extent": "0.4.0",
         "@mapbox/mapbox-gl-draw": "1.0.4",
@@ -98,9 +98,9 @@
           }
         },
         "es-abstract": {
-          "version": "1.14.2",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.14.2.tgz",
-          "integrity": "sha512-DgoQmbpFNOofkjJtKwr87Ma5EW4Dc8fWhD0R+ndq7Oc456ivUfGOOP6oAZTTKl5/CcNMP+EN+e3/iUzgE0veZg==",
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.15.0.tgz",
+          "integrity": "sha512-bhkEqWJ2t2lMeaJDuk7okMkJWI/yqgH/EoGwpcvv0XW9RWQsRspI4wt6xuyuvMvvQE3gg/D9HXppgk21w78GyQ==",
           "requires": {
             "es-to-primitive": "^1.2.0",
             "function-bind": "^1.1.1",
@@ -110,8 +110,8 @@
             "is-regex": "^1.0.4",
             "object-inspect": "^1.6.0",
             "object-keys": "^1.1.1",
-            "string.prototype.trimleft": "^2.0.0",
-            "string.prototype.trimright": "^2.0.0"
+            "string.prototype.trimleft": "^2.1.0",
+            "string.prototype.trimright": "^2.1.0"
           }
         },
         "es-to-primitive": {
@@ -275,9 +275,9 @@
           }
         },
         "react-is": {
-          "version": "16.9.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
-          "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw=="
+          "version": "16.10.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.1.tgz",
+          "integrity": "sha512-BXUMf9sIOPXXZWqr7+c5SeOKJykyVr2u0UDzEf4LNGc6taGkQe1A9DFD07umCIXz45RLr9oAAwZbAJ0Pkknfaw=="
         },
         "react-moment-proptypes": {
           "version": "1.7.0",
@@ -11982,11 +11982,11 @@
       }
     },
     "react-outside-click-handler": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/react-outside-click-handler/-/react-outside-click-handler-1.2.4.tgz",
-      "integrity": "sha512-FwLnTllTa65O/HjIyDgIrlAKcgPeXQnRUE+iR1EV4NY5opzN37S87+AtO1FF0rAa8qBDKj2QuNp4VfkjmkiB7g==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/react-outside-click-handler/-/react-outside-click-handler-1.3.0.tgz",
+      "integrity": "sha512-Te/7zFU0oHpAnctl//pP3hEAeobfeHMyygHB8MnjP6sX5OR8KHT1G3jmLsV3U9RnIYo+Yn+peJYWu+D5tUS8qQ==",
       "requires": {
-        "airbnb-prop-types": "^2.13.2",
+        "airbnb-prop-types": "^2.15.0",
         "consolidated-events": "^1.1.1 || ^2.0.0",
         "document.contains": "^1.0.1",
         "object.values": "^1.1.0",
@@ -12028,9 +12028,9 @@
           }
         },
         "es-abstract": {
-          "version": "1.14.2",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.14.2.tgz",
-          "integrity": "sha512-DgoQmbpFNOofkjJtKwr87Ma5EW4Dc8fWhD0R+ndq7Oc456ivUfGOOP6oAZTTKl5/CcNMP+EN+e3/iUzgE0veZg==",
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.15.0.tgz",
+          "integrity": "sha512-bhkEqWJ2t2lMeaJDuk7okMkJWI/yqgH/EoGwpcvv0XW9RWQsRspI4wt6xuyuvMvvQE3gg/D9HXppgk21w78GyQ==",
           "requires": {
             "es-to-primitive": "^1.2.0",
             "function-bind": "^1.1.1",
@@ -12040,8 +12040,8 @@
             "is-regex": "^1.0.4",
             "object-inspect": "^1.6.0",
             "object-keys": "^1.1.1",
-            "string.prototype.trimleft": "^2.0.0",
-            "string.prototype.trimright": "^2.0.0"
+            "string.prototype.trimleft": "^2.1.0",
+            "string.prototype.trimright": "^2.1.0"
           }
         },
         "es-to-primitive": {
@@ -12147,9 +12147,9 @@
           }
         },
         "react-is": {
-          "version": "16.9.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
-          "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw=="
+          "version": "16.10.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.1.tgz",
+          "integrity": "sha512-BXUMf9sIOPXXZWqr7+c5SeOKJykyVr2u0UDzEf4LNGc6taGkQe1A9DFD07umCIXz45RLr9oAAwZbAJ0Pkknfaw=="
         }
       }
     },
@@ -12664,9 +12664,9 @@
           }
         },
         "react-is": {
-          "version": "16.9.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
-          "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw=="
+          "version": "16.10.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.1.tgz",
+          "integrity": "sha512-BXUMf9sIOPXXZWqr7+c5SeOKJykyVr2u0UDzEf4LNGc6taGkQe1A9DFD07umCIXz45RLr9oAAwZbAJ0Pkknfaw=="
         }
       }
     },
@@ -12704,9 +12704,9 @@
           }
         },
         "react-is": {
-          "version": "16.9.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
-          "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw=="
+          "version": "16.10.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.1.tgz",
+          "integrity": "sha512-BXUMf9sIOPXXZWqr7+c5SeOKJykyVr2u0UDzEf4LNGc6taGkQe1A9DFD07umCIXz45RLr9oAAwZbAJ0Pkknfaw=="
         }
       }
     },
@@ -12748,9 +12748,9 @@
           }
         },
         "react-is": {
-          "version": "16.9.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
-          "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw=="
+          "version": "16.10.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.1.tgz",
+          "integrity": "sha512-BXUMf9sIOPXXZWqr7+c5SeOKJykyVr2u0UDzEf4LNGc6taGkQe1A9DFD07umCIXz45RLr9oAAwZbAJ0Pkknfaw=="
         }
       }
     },
@@ -12804,9 +12804,9 @@
           }
         },
         "es-abstract": {
-          "version": "1.14.2",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.14.2.tgz",
-          "integrity": "sha512-DgoQmbpFNOofkjJtKwr87Ma5EW4Dc8fWhD0R+ndq7Oc456ivUfGOOP6oAZTTKl5/CcNMP+EN+e3/iUzgE0veZg==",
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.15.0.tgz",
+          "integrity": "sha512-bhkEqWJ2t2lMeaJDuk7okMkJWI/yqgH/EoGwpcvv0XW9RWQsRspI4wt6xuyuvMvvQE3gg/D9HXppgk21w78GyQ==",
           "requires": {
             "es-to-primitive": "^1.2.0",
             "function-bind": "^1.1.1",
@@ -12816,8 +12816,8 @@
             "is-regex": "^1.0.4",
             "object-inspect": "^1.6.0",
             "object-keys": "^1.1.1",
-            "string.prototype.trimleft": "^2.0.0",
-            "string.prototype.trimright": "^2.0.0"
+            "string.prototype.trimleft": "^2.1.0",
+            "string.prototype.trimright": "^2.1.0"
           }
         },
         "es-to-primitive": {
@@ -12920,9 +12920,9 @@
           }
         },
         "react-is": {
-          "version": "16.9.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
-          "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw=="
+          "version": "16.10.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.1.tgz",
+          "integrity": "sha512-BXUMf9sIOPXXZWqr7+c5SeOKJykyVr2u0UDzEf4LNGc6taGkQe1A9DFD07umCIXz45RLr9oAAwZbAJ0Pkknfaw=="
         }
       }
     },
@@ -12964,9 +12964,9 @@
           }
         },
         "react-is": {
-          "version": "16.9.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
-          "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw=="
+          "version": "16.10.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.1.tgz",
+          "integrity": "sha512-BXUMf9sIOPXXZWqr7+c5SeOKJykyVr2u0UDzEf4LNGc6taGkQe1A9DFD07umCIXz45RLr9oAAwZbAJ0Pkknfaw=="
         }
       }
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,7 +35,7 @@
     "validateComponents:linux:darwin": "./scripts/validateComponents.sh"
   },
   "dependencies": {
-    "@attivio/suit": "^1.0.5",
+    "@attivio/suit": "^1.0.6",
     "@mapbox/mapbox-gl-draw": "^1.0.4",
     "babel-polyfill": "^6.26.0",
     "es6-object-assign": "^1.1.0",


### PR DESCRIPTION
Bumps up [`attivio/suit`](https://github.com/attivio/suit/pull/166) to [`v1.0.6`](https://github.com/attivio/suit/releases/tag/v1.0.6).

[`attivio/suit`] `v1.0.6` (https://github.com/attivio/suit/pull/166) Release Notes
>Fixes regression where using a number type in `<SearchFacetBuckets />` caused an error.

This relates to [PLAT-40591](https://jira.attivio.com/browse/PLAT-40591).

Release Target: `5.6.3`.