### PR TITLE
chore/PLAT-40591: Bump up attivio/suit to v1.0.6

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@attivio/suit": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@attivio/suit/-/suit-1.0.3.tgz",
-      "integrity": "sha512-vVHW6Fkl/xmg9YWaiX/CscUVDmM998HWyYR8kIwWrmunGmph2MG+/3Te8njKKm45PgpvtGbkKcZRrlBNTSX9NQ==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@attivio/suit/-/suit-1.0.6.tgz",
+      "integrity": "sha512-Whda+3WENxwvOOG9V6egX6GrmJyRPRS2vK9/RT0IRfqnSvs1lSXv3kio4Lzb6FDAhHltb0TruX4ltW98P4sF1Q==",
       "requires": {
         "@mapbox/extent": "0.4.0",
         "@mapbox/mapbox-gl-draw": "1.0.4",
@@ -98,16 +98,20 @@
           }
         },
         "es-abstract": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
-          "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.15.0.tgz",
+          "integrity": "sha512-bhkEqWJ2t2lMeaJDuk7okMkJWI/yqgH/EoGwpcvv0XW9RWQsRspI4wt6xuyuvMvvQE3gg/D9HXppgk21w78GyQ==",
           "requires": {
             "es-to-primitive": "^1.2.0",
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
+            "has-symbols": "^1.0.0",
             "is-callable": "^1.1.4",
             "is-regex": "^1.0.4",
-            "object-keys": "^1.0.12"
+            "object-inspect": "^1.6.0",
+            "object-keys": "^1.1.1",
+            "string.prototype.trimleft": "^2.1.0",
+            "string.prototype.trimright": "^2.1.0"
           }
         },
         "es-to-primitive": {
@@ -156,6 +160,11 @@
           "version": "4.17.15",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
           "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        },
+        "object-inspect": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
+          "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ=="
         },
         "object-keys": {
           "version": "1.1.1",
@@ -266,9 +275,9 @@
           }
         },
         "react-is": {
-          "version": "16.9.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
-          "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw=="
+          "version": "16.10.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.1.tgz",
+          "integrity": "sha512-BXUMf9sIOPXXZWqr7+c5SeOKJykyVr2u0UDzEf4LNGc6taGkQe1A9DFD07umCIXz45RLr9oAAwZbAJ0Pkknfaw=="
         },
         "react-moment-proptypes": {
           "version": "1.7.0",
@@ -297,9 +306,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
-      "integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.2.tgz",
+      "integrity": "sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==",
       "requires": {
         "regenerator-runtime": "^0.13.2"
       },
@@ -312,9 +321,9 @@
       }
     },
     "@babel/runtime-corejs2": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.5.5.tgz",
-      "integrity": "sha512-FYATQVR00NSNi7mUfpPDp7E8RYMXDuO8gaix7u/w3GekfUinKgX1AcTxs7SoiEmoEW9mbpjrwqWSW6zCmw5h8A==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.6.2.tgz",
+      "integrity": "sha512-wdyVKnTv9Be4YlwF/7pByYNfcl23qC21aAQ0aIaZOo2ZOvhFEyJdBLJClYZ9i+Pmrz7sUQgg/MwbJa2RZTkygg==",
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.2"
@@ -4088,9 +4097,9 @@
       "dev": true
     },
     "ejs": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.2.tgz",
-      "integrity": "sha512-PcW2a0tyTuPHz3tWyYqtK6r1fZ3gp+3Sop8Ph+ZYN81Ob5rwmbHEzaqs10N3BEsaGTkh/ooniXK+WwszGlc2+Q=="
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.1.tgz",
+      "integrity": "sha512-kS/gEPzZs3Y1rRsbGX4UOSjtP/CeJP0CxSNZHYxGfVM/VgLcv0ZqM7C45YyTj2DI2g7+P9Dd24C+IMIg6D0nYQ=="
     },
     "electron-to-chromium": {
       "version": "1.3.34",
@@ -11930,11 +11939,11 @@
       }
     },
     "react-outside-click-handler": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/react-outside-click-handler/-/react-outside-click-handler-1.2.4.tgz",
-      "integrity": "sha512-FwLnTllTa65O/HjIyDgIrlAKcgPeXQnRUE+iR1EV4NY5opzN37S87+AtO1FF0rAa8qBDKj2QuNp4VfkjmkiB7g==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/react-outside-click-handler/-/react-outside-click-handler-1.3.0.tgz",
+      "integrity": "sha512-Te/7zFU0oHpAnctl//pP3hEAeobfeHMyygHB8MnjP6sX5OR8KHT1G3jmLsV3U9RnIYo+Yn+peJYWu+D5tUS8qQ==",
       "requires": {
-        "airbnb-prop-types": "^2.13.2",
+        "airbnb-prop-types": "^2.15.0",
         "consolidated-events": "^1.1.1 || ^2.0.0",
         "document.contains": "^1.0.1",
         "object.values": "^1.1.0",
@@ -11976,16 +11985,20 @@
           }
         },
         "es-abstract": {
-          "version": "1.13.0",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
-          "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.15.0.tgz",
+          "integrity": "sha512-bhkEqWJ2t2lMeaJDuk7okMkJWI/yqgH/EoGwpcvv0XW9RWQsRspI4wt6xuyuvMvvQE3gg/D9HXppgk21w78GyQ==",
           "requires": {
             "es-to-primitive": "^1.2.0",
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
+            "has-symbols": "^1.0.0",
             "is-callable": "^1.1.4",
             "is-regex": "^1.0.4",
-            "object-keys": "^1.0.12"
+            "object-inspect": "^1.6.0",
+            "object-keys": "^1.1.1",
+            "string.prototype.trimleft": "^2.1.0",
+            "string.prototype.trimright": "^2.1.0"
           }
         },
         "es-to-primitive": {
@@ -12038,6 +12051,11 @@
             "js-tokens": "^3.0.0 || ^4.0.0"
           }
         },
+        "object-inspect": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
+          "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ=="
+        },
         "object-keys": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -12086,9 +12104,9 @@
           }
         },
         "react-is": {
-          "version": "16.9.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
-          "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw=="
+          "version": "16.10.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.1.tgz",
+          "integrity": "sha512-BXUMf9sIOPXXZWqr7+c5SeOKJykyVr2u0UDzEf4LNGc6taGkQe1A9DFD07umCIXz45RLr9oAAwZbAJ0Pkknfaw=="
         }
       }
     },
@@ -12603,9 +12621,9 @@
           }
         },
         "react-is": {
-          "version": "16.9.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
-          "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw=="
+          "version": "16.10.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.1.tgz",
+          "integrity": "sha512-BXUMf9sIOPXXZWqr7+c5SeOKJykyVr2u0UDzEf4LNGc6taGkQe1A9DFD07umCIXz45RLr9oAAwZbAJ0Pkknfaw=="
         }
       }
     },
@@ -12643,9 +12661,9 @@
           }
         },
         "react-is": {
-          "version": "16.9.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
-          "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw=="
+          "version": "16.10.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.1.tgz",
+          "integrity": "sha512-BXUMf9sIOPXXZWqr7+c5SeOKJykyVr2u0UDzEf4LNGc6taGkQe1A9DFD07umCIXz45RLr9oAAwZbAJ0Pkknfaw=="
         }
       }
     },
@@ -12687,31 +12705,127 @@
           }
         },
         "react-is": {
-          "version": "16.9.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
-          "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw=="
+          "version": "16.10.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.1.tgz",
+          "integrity": "sha512-BXUMf9sIOPXXZWqr7+c5SeOKJykyVr2u0UDzEf4LNGc6taGkQe1A9DFD07umCIXz45RLr9oAAwZbAJ0Pkknfaw=="
         }
       }
     },
     "react-with-direction": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/react-with-direction/-/react-with-direction-1.3.0.tgz",
-      "integrity": "sha512-2TflEebNckTNUybw3Rzqjg4BwM/H380ZL5lsbZ5f4UTY2JyE5uQdQZK5T2w+BDJSAMcqoA2RDJYa4e7Cl6C2Kg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/react-with-direction/-/react-with-direction-1.3.1.tgz",
+      "integrity": "sha512-aGcM21ZzhqeXFvDCfPj0rVNYuaVXfTz5D3Rbn0QMz/unZe+CCiLHthrjQWO7s6qdfXORgYFtmS7OVsRgSk5LXQ==",
       "requires": {
-        "airbnb-prop-types": "^2.8.1",
+        "airbnb-prop-types": "^2.10.0",
         "brcast": "^2.0.2",
-        "deepmerge": "^1.5.1",
-        "direction": "^1.0.1",
-        "hoist-non-react-statics": "^2.3.1",
+        "deepmerge": "^1.5.2",
+        "direction": "^1.0.2",
+        "hoist-non-react-statics": "^3.3.0",
         "object.assign": "^4.1.0",
         "object.values": "^1.0.4",
-        "prop-types": "^15.6.0"
+        "prop-types": "^15.6.2"
       },
       "dependencies": {
+        "airbnb-prop-types": {
+          "version": "2.15.0",
+          "resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.15.0.tgz",
+          "integrity": "sha512-jUh2/hfKsRjNFC4XONQrxo/n/3GG4Tn6Hl0WlFQN5PY9OMC9loSCoAYKnZsWaP8wEfd5xcrPloK0Zg6iS1xwVA==",
+          "requires": {
+            "array.prototype.find": "^2.1.0",
+            "function.prototype.name": "^1.1.1",
+            "has": "^1.0.3",
+            "is-regex": "^1.0.4",
+            "object-is": "^1.0.1",
+            "object.assign": "^4.1.0",
+            "object.entries": "^1.1.0",
+            "prop-types": "^15.7.2",
+            "prop-types-exact": "^1.2.0",
+            "react-is": "^16.9.0"
+          }
+        },
+        "array.prototype.find": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.1.0.tgz",
+          "integrity": "sha512-Wn41+K1yuO5p7wRZDl7890c3xvv5UBrfVXTVIe28rSQb6LS0fZMDrQB6PAcxQFRFy6vJTLDc3A2+3CjQdzVKRg==",
+          "requires": {
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.13.0"
+          }
+        },
+        "define-properties": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+          "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+          "requires": {
+            "object-keys": "^1.0.12"
+          }
+        },
+        "es-abstract": {
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.15.0.tgz",
+          "integrity": "sha512-bhkEqWJ2t2lMeaJDuk7okMkJWI/yqgH/EoGwpcvv0XW9RWQsRspI4wt6xuyuvMvvQE3gg/D9HXppgk21w78GyQ==",
+          "requires": {
+            "es-to-primitive": "^1.2.0",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.0",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-inspect": "^1.6.0",
+            "object-keys": "^1.1.1",
+            "string.prototype.trimleft": "^2.1.0",
+            "string.prototype.trimright": "^2.1.0"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+          "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+          "requires": {
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
+          }
+        },
+        "function.prototype.name": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.1.tgz",
+          "integrity": "sha512-e1NzkiJuw6xqVH7YSdiW/qDHebcmMhPNe6w+4ZYYEg0VA+LaLzx37RimbPLuonHhYGFGPx1ME2nSi74JiaCr/Q==",
+          "requires": {
+            "define-properties": "^1.1.3",
+            "function-bind": "^1.1.1",
+            "functions-have-names": "^1.1.1",
+            "is-callable": "^1.1.4"
+          }
+        },
+        "has": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+          "requires": {
+            "function-bind": "^1.1.1"
+          }
+        },
         "hoist-non-react-statics": {
-          "version": "2.5.5",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
+          "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+          "requires": {
+            "react-is": "^16.7.0"
+          }
+        },
+        "is-callable": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+          "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
+        },
+        "is-symbol": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+          "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+          "requires": {
+            "has-symbols": "^1.0.0"
+          }
         },
         "loose-envify": {
           "version": "1.4.0",
@@ -12719,6 +12833,27 @@
           "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
           "requires": {
             "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-inspect": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
+          "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ=="
+        },
+        "object-keys": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+        },
+        "object.entries": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
+          "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
+          "requires": {
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.12.0",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3"
           }
         },
         "prop-types": {
@@ -12731,10 +12866,20 @@
             "react-is": "^16.8.1"
           }
         },
+        "prop-types-exact": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/prop-types-exact/-/prop-types-exact-1.2.0.tgz",
+          "integrity": "sha512-K+Tk3Kd9V0odiXFP9fwDHUYRyvK3Nun3GVyPapSIs5OBkITAm15W0CPFD/YKTkMUAbc0b9CUwRQp2ybiBIq+eA==",
+          "requires": {
+            "has": "^1.0.3",
+            "object.assign": "^4.1.0",
+            "reflect.ownkeys": "^0.2.0"
+          }
+        },
         "react-is": {
-          "version": "16.9.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
-          "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw=="
+          "version": "16.10.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.1.tgz",
+          "integrity": "sha512-BXUMf9sIOPXXZWqr7+c5SeOKJykyVr2u0UDzEf4LNGc6taGkQe1A9DFD07umCIXz45RLr9oAAwZbAJ0Pkknfaw=="
         }
       }
     },
@@ -12776,9 +12921,9 @@
           }
         },
         "react-is": {
-          "version": "16.9.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
-          "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw=="
+          "version": "16.10.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.1.tgz",
+          "integrity": "sha512-BXUMf9sIOPXXZWqr7+c5SeOKJykyVr2u0UDzEf4LNGc6taGkQe1A9DFD07umCIXz45RLr9oAAwZbAJ0Pkknfaw=="
         }
       }
     },
@@ -14252,6 +14397,54 @@
           "requires": {
             "ansi-regex": "^2.0.0"
           }
+        }
+      }
+    },
+    "string.prototype.trimleft": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
+      "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      },
+      "dependencies": {
+        "define-properties": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+          "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+          "requires": {
+            "object-keys": "^1.0.12"
+          }
+        },
+        "object-keys": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+        }
+      }
+    },
+    "string.prototype.trimright": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
+      "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      },
+      "dependencies": {
+        "define-properties": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+          "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+          "requires": {
+            "object-keys": "^1.0.12"
+          }
+        },
+        "object-keys": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
         }
       }
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,7 +35,7 @@
     "validateComponents:linux:darwin": "./scripts/validateComponents.sh"
   },
   "dependencies": {
-    "@attivio/suit": "^1.0.3",
+    "@attivio/suit": "^1.0.6",
     "@mapbox/mapbox-gl-draw": "^1.0.4",
     "babel-polyfill": "^6.26.0",
     "es6-object-assign": "^1.1.0",


### PR DESCRIPTION
Bumps up [`attivio/suit`](https://github.com/attivio/suit/pull/166) to [`v1.0.6`](https://github.com/attivio/suit/releases/tag/v1.0.6).

[`attivio/suit`] `v1.0.6` (https://github.com/attivio/suit/pull/166) Release Notes
>Fixes regression where using a number type in `<SearchFacetBuckets />` caused an error.

This relates to [PLAT-40591](https://jira.attivio.com/browse/PLAT-40591).

These changes are also targeted for merge into branch [`release/version5.6.3`](https://github.com/attivio/searchui/pull/98).