### PR TITLE
Feat/plat 44338 c

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5514,8 +5514,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.1.1",
@@ -5566,8 +5565,7 @@
         "balanced-match": {
           "version": "0.4.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.1",
@@ -5582,7 +5580,6 @@
           "version": "0.0.9",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "inherits": "~2.0.0"
           }
@@ -5591,7 +5588,6 @@
           "version": "2.10.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "hoek": "2.x.x"
           }
@@ -5600,7 +5596,6 @@
           "version": "1.1.7",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^0.4.1",
             "concat-map": "0.0.1"
@@ -5609,8 +5604,7 @@
         "buffer-shims": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "caseless": {
           "version": "0.12.0",
@@ -5627,14 +5621,12 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "combined-stream": {
           "version": "1.0.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "delayed-stream": "~1.0.0"
           }
@@ -5642,26 +5634,22 @@
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "cryptiles": {
           "version": "2.0.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "boom": "2.x.x"
           }
@@ -5701,8 +5689,7 @@
         "delayed-stream": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "delegates": {
           "version": "1.0.0",
@@ -5734,8 +5721,7 @@
         "extsprintf": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "forever-agent": {
           "version": "0.6.1",
@@ -5757,14 +5743,12 @@
         "fs.realpath": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "fstream": {
           "version": "1.0.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "inherits": "~2.0.0",
@@ -5820,7 +5804,6 @@
           "version": "7.1.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -5833,8 +5816,7 @@
         "graceful-fs": {
           "version": "4.1.11",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "har-schema": {
           "version": "1.0.5",
@@ -5862,7 +5844,6 @@
           "version": "3.1.3",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "boom": "2.x.x",
             "cryptiles": "2.x.x",
@@ -5873,8 +5854,7 @@
         "hoek": {
           "version": "2.16.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "http-signature": {
           "version": "1.1.1",
@@ -5891,7 +5871,6 @@
           "version": "1.0.6",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -5900,8 +5879,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.4",
@@ -5913,7 +5891,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5927,8 +5904,7 @@
         "isarray": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "isstream": {
           "version": "0.1.2",
@@ -6001,14 +5977,12 @@
         "mime-db": {
           "version": "1.27.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "mime-types": {
           "version": "2.1.15",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "mime-db": "~1.27.0"
           }
@@ -6017,7 +5991,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6025,14 +5998,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6087,8 +6058,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "oauth-sign": {
           "version": "0.8.2",
@@ -6106,7 +6076,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6136,8 +6105,7 @@
         "path-is-absolute": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "performance-now": {
           "version": "0.2.0",
@@ -6148,8 +6116,7 @@
         "process-nextick-args": {
           "version": "1.0.7",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "punycode": {
           "version": "1.4.1",
@@ -6187,7 +6154,6 @@
           "version": "2.2.9",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "buffer-shims": "~1.0.0",
             "core-util-is": "~1.0.0",
@@ -6232,7 +6198,6 @@
           "version": "2.6.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "glob": "^7.0.5"
           }
@@ -6240,8 +6205,7 @@
         "safe-buffer": {
           "version": "5.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "semver": {
           "version": "5.3.0",
@@ -6265,7 +6229,6 @@
           "version": "1.0.9",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "hoek": "2.x.x"
           }
@@ -6299,7 +6262,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6310,7 +6272,6 @@
           "version": "1.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.0.1"
           }
@@ -6325,7 +6286,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6340,7 +6300,6 @@
           "version": "2.2.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "block-stream": "*",
             "fstream": "^1.0.2",
@@ -6396,8 +6355,7 @@
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "uuid": {
           "version": "3.0.1",
@@ -6426,8 +6384,7 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -15873,8 +15830,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -15895,14 +15851,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -15917,20 +15871,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -16047,8 +15998,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -16060,7 +16010,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -16075,7 +16024,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -16083,14 +16031,12 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.2.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.1",
                 "yallist": "^3.0.0"
@@ -16109,7 +16055,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -16190,8 +16135,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -16203,7 +16147,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -16289,8 +16232,7 @@
             "safe-buffer": {
               "version": "5.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -16326,7 +16268,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -16346,7 +16287,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -16390,14 +16330,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -17071,8 +17009,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -17093,14 +17030,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -17115,20 +17050,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -17245,8 +17177,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -17258,7 +17189,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -17273,7 +17203,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -17281,14 +17210,12 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.2.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.1",
                 "yallist": "^3.0.0"
@@ -17307,7 +17234,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -17388,8 +17314,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -17401,7 +17326,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -17487,8 +17411,7 @@
             "safe-buffer": {
               "version": "5.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -17524,7 +17447,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -17544,7 +17466,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -17588,14 +17509,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@attivio/searchui",
-  "version": "0.0.1",
+  "version": "5.6.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@attivio/searchui",
-  "version": "0.0.1",
+  "version": "5.6.4",
   "description": "Framework for building search user-interface applications on top of the Attivio platform.",
   "keywords": [
     "Attivio",

--- a/frontend/src/SearchUIApp.js
+++ b/frontend/src/SearchUIApp.js
@@ -132,18 +132,12 @@ export default class SearchUIApp extends React.Component<void, {}, SearchUIAppSt
     app: PropTypes.shape({ type: PropTypes.oneOf([SearchUIApp]) }),
   };
 
-  constructor(props: {}) {
-    super(props);
-    this.state = {
-      config: null,
-      users: null,
-      loading: true,
-      configurationError: null,
-    };
-    (this: any).configureSuit = this.configureSuit.bind(this);
-  }
-
-  state: SearchUIAppState;
+  state: SearchUIAppState = {
+    config: null,
+    configurationError: null,
+    loading: true,
+    users: null,
+  };
 
   getChildContext() {
     return {
@@ -207,7 +201,7 @@ export default class SearchUIApp extends React.Component<void, {}, SearchUIAppSt
     ];
   }
 
-  configureSuit() {
+  configureSuit = () => {
     if (this.state.loading) {
       if (this.state.configurationError) {
         this.setState({

--- a/frontend/src/SearchUIApp.js
+++ b/frontend/src/SearchUIApp.js
@@ -69,6 +69,7 @@ export default class SearchUIApp extends React.Component<void, {}, SearchUIAppSt
     '/',
     '/landing',
     '/results',
+    '/results/no-mast',
     '/insights',
     '/doc360',
     '/locallogin',
@@ -150,7 +151,7 @@ export default class SearchUIApp extends React.Component<void, {}, SearchUIAppSt
     };
   }
 
-  componentWillMount() {
+  componentDidMount() {
     SearchUIApp.loadConfig('configuration', (data: string | null, error: string | null) => {
       if (data) {
         try {
@@ -274,6 +275,7 @@ export default class SearchUIApp extends React.Component<void, {}, SearchUIAppSt
                 <AuthRoute exact path="/" component={SearchUILandingPage} />
                 <AuthRoute exact path="/landing" component={SearchUIFakeLandingPage} />
                 <AuthRoute exact path="/results" component={SearchUISearchPage} />
+                <AuthRoute exact path="/results/no-mast" component={SearchUISearchPage} />
                 <AuthRoute exact path="/insights" component={SearchUIInsightsPage} />
                 <AuthRoute exact path="/doc360" component={Document360Page} />
                 <Route exact path="/locallogin" component={LoginPage} />

--- a/frontend/src/SearchUIApp.js
+++ b/frontend/src/SearchUIApp.js
@@ -69,7 +69,7 @@ export default class SearchUIApp extends React.Component<void, {}, SearchUIAppSt
     '/',
     '/landing',
     '/results',
-    '/results/no-mast',
+    '/results-no-mast',
     '/insights',
     '/doc360',
     '/locallogin',
@@ -269,7 +269,7 @@ export default class SearchUIApp extends React.Component<void, {}, SearchUIAppSt
                 <AuthRoute exact path="/" component={SearchUILandingPage} />
                 <AuthRoute exact path="/landing" component={SearchUIFakeLandingPage} />
                 <AuthRoute exact path="/results" component={SearchUISearchPage} />
-                <AuthRoute exact path="/results/no-mast" component={SearchUISearchPage} />
+                <AuthRoute exact path="/results-no-mast" component={SearchUISearchPage} />
                 <AuthRoute exact path="/insights" component={SearchUIInsightsPage} />
                 <AuthRoute exact path="/doc360" component={Document360Page} />
                 <Route exact path="/locallogin" component={LoginPage} />

--- a/frontend/src/pages/Document360Page.js
+++ b/frontend/src/pages/Document360Page.js
@@ -154,7 +154,7 @@ class Document360Page extends React.Component<Document360PageDefaultProps, Docum
 
   state: Document360PageState;
 
-  componentWillMount() {
+  componentDidMount() {
     const search = QueryString.parse(this.props.location.search);
     const docId = search.docId;
     this.setDocId(docId);

--- a/frontend/src/pages/SearchUIFakeLandingPage.js
+++ b/frontend/src/pages/SearchUIFakeLandingPage.js
@@ -10,8 +10,8 @@ class SearchUIFakeLandingPage extends React.Component<void, {}, void> {
   };
 
   componentDidMount() {
-    const searcher = this.context.searcher;
-    const router = this.context.router;
+    const { searcher, router } = this.context;
+
     if (searcher && router) {
       searcher.reset(() => {
         const newQueryString = searcher.generateLocationQueryStringFromState(searcher.state);

--- a/frontend/src/pages/SearchUIInsightsPage.js
+++ b/frontend/src/pages/SearchUIInsightsPage.js
@@ -62,10 +62,12 @@ class SearchUIInsightsPage extends React.Component<SearchUIInsightsPageProps, Se
   };
 
   render() {
+    const { app } = this.context;
+
     return (
       <div>
         <Masthead multiline homeRoute="/landing" logoutFunction={AuthUtils.logout}>
-          <MastheadNavTabs initialTab="/insights" tabInfo={this.context.app.getMastheadNavTabs()} />
+          <MastheadNavTabs initialTab="/insights" tabInfo={app.getMastheadNavTabs()} />
           <SearchBar
             inMasthead
           />

--- a/frontend/src/pages/SearchUILandingPage.js
+++ b/frontend/src/pages/SearchUILandingPage.js
@@ -64,7 +64,7 @@ class SearchUILandingPage extends React.Component<SearchUILandingPageDefaultProp
   state: SearchUILandingPageState;
 
   componentDidMount() {
-    const searcher = this.context.searcher;
+    const { searcher } = this.context;
     searcher.state.response = undefined;
     if (searcher) {
       const qr = new SimpleQueryRequest();

--- a/frontend/src/pages/SearchUISearchPage.js
+++ b/frontend/src/pages/SearchUISearchPage.js
@@ -1,7 +1,6 @@
 // @flow
 import React from 'react';
 import PropTypes from 'prop-types';
-import QueryString from 'query-string';
 import { withRouter } from 'react-router-dom';
 import Col from 'react-bootstrap/lib/Col';
 import Grid from 'react-bootstrap/lib/Grid';
@@ -99,7 +98,7 @@ type SearchUISearchPageProps = {
    */
   searchEngineType: 'attivio' | 'solr' | 'elastic';
   /**
-   * Location object injected by withRouter.
+   * location object injected by withRouter.
    */
   location: {};
 };
@@ -182,7 +181,9 @@ class SearchUISearchPage extends React.Component<SearchUISearchPageProps, Search
       entityColors,
       entityFields,
       geoMapFacets,
-      location,
+      location: {
+        pathname,
+      },
       maxFacetBuckets,
       orderHint,
       pieChartFacets,
@@ -194,8 +195,8 @@ class SearchUISearchPage extends React.Component<SearchUISearchPageProps, Search
 
     const showTags = searchEngineType === 'attivio';
     const showScores = this.props.showScores && showTags;
-    const queryParams = location && location.search ? QueryString.parse(location.search) : null;
-    const hideMasthead = queryParams && queryParams.nomast;
+
+    const hideMasthead = pathname && pathname.includes('no-mast');
 
     return (
       <div>

--- a/frontend/src/pages/SearchUISearchPage.js
+++ b/frontend/src/pages/SearchUISearchPage.js
@@ -151,6 +151,12 @@ class SearchUISearchPage extends React.Component<SearchUISearchPageProps, Search
   }
 
   renderSecondaryNavBar(hideMasthead: boolean) {
+    const {
+      baseUri,
+      relevancyModels,
+      sortableFields,
+    } = this.props;
+
     return (
       <SecondaryNavBar>
         <SearchResultsCount />
@@ -159,11 +165,11 @@ class SearchUISearchPage extends React.Component<SearchUISearchPageProps, Search
         <SearchResultsPager right />
         <SearchRelevancyModel
           right
-          baseUri={this.props.baseUri}
-          models={this.props.relevancyModels}
+          baseUri={baseUri}
+          models={relevancyModels}
         />
         <NavbarSort
-          fieldNames={this.props.sortableFields}
+          fieldNames={sortableFields}
           includeRelevancy
           right
         />
@@ -189,12 +195,15 @@ class SearchUISearchPage extends React.Component<SearchUISearchPageProps, Search
       pieChartFacets,
       searchEngineType,
       sentimentFacets,
+      showScores,
       tagCloudFacets,
       timeSeriesFacets,
     } = this.props;
 
+    const { app = null, searcher = null } = this.context;
+
     const showTags = searchEngineType === 'attivio';
-    const showScores = this.props.showScores && showTags;
+    const showScoresInSearchResults = showScores && showTags;
 
     const hideMasthead = pathname && pathname.includes('no-mast');
 
@@ -202,7 +211,10 @@ class SearchUISearchPage extends React.Component<SearchUISearchPageProps, Search
       <div>
         {!hideMasthead &&
           <Masthead multiline homeRoute="/landing" logoutFunction={AuthUtils.logout}>
-            <MastheadNavTabs initialTab="/results" tabInfo={this.context.app.getMastheadNavTabs()} />
+            <MastheadNavTabs
+              initialTab="/results"
+              tabInfo={app ? app.getMastheadNavTabs() : []}
+            />
             <SearchBar inMasthead />
           </Masthead>
         }
@@ -229,10 +241,10 @@ class SearchUISearchPage extends React.Component<SearchUISearchPageProps, Search
                 <PlacementResults />
                 <SpellCheckMessage />
                 <SearchResults
-                  format={this.context.searcher.state.format}
+                  format={searcher && searcher.state ? searcher.state.format : null}
                   entityFields={entityFields}
                   baseUri={baseUri}
-                  showScores={showScores}
+                  showScores={showScoresInSearchResults}
                   showTags={showTags}
                 />
               </Col>

--- a/frontend/src/pages/SearchUISearchPage.js
+++ b/frontend/src/pages/SearchUISearchPage.js
@@ -246,6 +246,7 @@ class SearchUISearchPage extends React.Component<SearchUISearchPageProps, Search
                   baseUri={baseUri}
                   showScores={showScoresInSearchResults}
                   showTags={showTags}
+                  show360={!hideMasthead}
                 />
               </Col>
             </Row>

--- a/frontend/src/pages/SearchUISearchPage.js
+++ b/frontend/src/pages/SearchUISearchPage.js
@@ -98,6 +98,10 @@ type SearchUISearchPageProps = {
    * search results are rendered.
    */
   searchEngineType: 'attivio' | 'solr' | 'elastic';
+  /**
+   * Location object injected by withRouter.
+   */
+  location: {};
 };
 
 /**
@@ -184,18 +188,18 @@ class SearchUISearchPage extends React.Component<SearchUISearchPageProps, Search
       pieChartFacets,
       searchEngineType,
       sentimentFacets,
-      showScores,
       tagCloudFacets,
-    }
-    
+      timeSeriesFacets,
+    } = this.props;
+
     const showTags = searchEngineType === 'attivio';
-    const showScores = showScores && showTags;
-    const queryParams = QueryString.parse(location.search);
+    const showScores = this.props.showScores && showTags;
+    const queryParams = location && location.search ? QueryString.parse(location.search) : null;
     const hideMasthead = queryParams && queryParams.nomast;
 
     return (
       <div>
-        {!hideMasthead && 
+        {!hideMasthead &&
           <Masthead multiline homeRoute="/landing" logoutFunction={AuthUtils.logout}>
             <MastheadNavTabs initialTab="/results" tabInfo={this.context.app.getMastheadNavTabs()} />
             <SearchBar inMasthead />
@@ -239,4 +243,4 @@ class SearchUISearchPage extends React.Component<SearchUISearchPageProps, Search
   }
 }
 
-export default Configurable(SearchUISearchPage);
+export default withRouter(Configurable(SearchUISearchPage));

--- a/frontend/src/pages/SearchUISearchPage.js
+++ b/frontend/src/pages/SearchUISearchPage.js
@@ -1,7 +1,8 @@
 // @flow
 import React from 'react';
 import PropTypes from 'prop-types';
-
+import QueryString from 'query-string';
+import { withRouter } from 'react-router-dom';
 import Col from 'react-bootstrap/lib/Col';
 import Grid from 'react-bootstrap/lib/Grid';
 import Row from 'react-bootstrap/lib/Row';
@@ -139,14 +140,18 @@ class SearchUISearchPage extends React.Component<SearchUISearchPageProps, Search
     app: PropTypes.shape({ type: PropTypes.oneOf([SearchUIApp]) }),
   };
 
-  componentWillMount() {
-    this.context.searcher.doSearch();
+  componentDidMount() {
+    const { searcher = null } = this.context;
+    if (searcher) {
+      searcher.doSearch();
+    }
   }
 
-  renderSecondaryNavBar() {
+  renderSecondaryNavBar(hideMasthead: boolean) {
     return (
       <SecondaryNavBar>
         <SearchResultsCount />
+        {hideMasthead && <SearchBar />}
         <SearchResultsFacetFilters />
         <SearchResultsPager right />
         <SearchRelevancyModel
@@ -165,33 +170,54 @@ class SearchUISearchPage extends React.Component<SearchUISearchPageProps, Search
   }
 
   render() {
-    const showScores = this.props.showScores && this.props.searchEngineType === 'attivio';
-    const showTags = this.props.searchEngineType === 'attivio';
+    const {
+      barChartFacets,
+      barListFacets,
+      baseUri,
+      columnChartFacets,
+      entityColors,
+      entityFields,
+      geoMapFacets,
+      location,
+      maxFacetBuckets,
+      orderHint,
+      pieChartFacets,
+      searchEngineType,
+      sentimentFacets,
+      showScores,
+      tagCloudFacets,
+    }
+    
+    const showTags = searchEngineType === 'attivio';
+    const showScores = showScores && showTags;
+    const queryParams = QueryString.parse(location.search);
+    const hideMasthead = queryParams && queryParams.nomast;
+
     return (
       <div>
-        <Masthead multiline homeRoute="/landing" logoutFunction={AuthUtils.logout}>
-          <MastheadNavTabs initialTab="/results" tabInfo={this.context.app.getMastheadNavTabs()} />
-          <SearchBar
-            inMasthead
-          />
-        </Masthead>
-        {this.renderSecondaryNavBar()}
+        {!hideMasthead && 
+          <Masthead multiline homeRoute="/landing" logoutFunction={AuthUtils.logout}>
+            <MastheadNavTabs initialTab="/results" tabInfo={this.context.app.getMastheadNavTabs()} />
+            <SearchBar inMasthead />
+          </Masthead>
+        }
+        {this.renderSecondaryNavBar(hideMasthead)}
         <div style={{ padding: '10px' }}>
           <Grid fluid>
             <Row>
               <Col xs={12} sm={5} md={4} lg={3}>
                 <FacetResults
-                  pieChartFacets={this.props.pieChartFacets}
-                  barChartFacets={this.props.barChartFacets}
-                  columnChartFacets={this.props.columnChartFacets}
-                  barListFacets={this.props.barListFacets}
-                  tagCloudFacets={this.props.tagCloudFacets}
-                  timeSeriesFacets={this.props.timeSeriesFacets}
-                  sentimentFacets={this.props.sentimentFacets}
-                  geoMapFacets={this.props.geoMapFacets}
-                  maxFacetBuckets={this.props.maxFacetBuckets}
-                  orderHint={this.props.orderHint}
-                  entityColors={this.props.entityColors}
+                  pieChartFacets={pieChartFacets}
+                  barChartFacets={barChartFacets}
+                  columnChartFacets={columnChartFacets}
+                  barListFacets={barListFacets}
+                  tagCloudFacets={tagCloudFacets}
+                  timeSeriesFacets={timeSeriesFacets}
+                  sentimentFacets={sentimentFacets}
+                  geoMapFacets={geoMapFacets}
+                  maxFacetBuckets={maxFacetBuckets}
+                  orderHint={orderHint}
+                  entityColors={entityColors}
                 />
               </Col>
               <Col xs={12} sm={7} md={8} lg={9}>
@@ -199,8 +225,8 @@ class SearchUISearchPage extends React.Component<SearchUISearchPageProps, Search
                 <SpellCheckMessage />
                 <SearchResults
                   format={this.context.searcher.state.format}
-                  entityFields={this.props.entityFields}
-                  baseUri={this.props.baseUri}
+                  entityFields={entityFields}
+                  baseUri={baseUri}
                   showScores={showScores}
                   showTags={showTags}
                 />

--- a/module/src/main/resources/webapps/searchui/WEB-INF/searchui-servlet.xml
+++ b/module/src/main/resources/webapps/searchui/WEB-INF/searchui-servlet.xml
@@ -25,6 +25,7 @@
   <mvc:view-controller path="/" view-name="index" />
   <mvc:view-controller path="landing" view-name="index" />
   <mvc:view-controller path="/results" view-name="index" />
+  <mvc:view-controller path="/results/no-mast" view-name="index" />
   <mvc:view-controller path="/insights" view-name="index" />
   <mvc:view-controller path="/doc360" view-name="index" />
   <mvc:view-controller path="login" view-name="index" />

--- a/module/src/main/resources/webapps/searchui/WEB-INF/searchui-servlet.xml
+++ b/module/src/main/resources/webapps/searchui/WEB-INF/searchui-servlet.xml
@@ -25,7 +25,7 @@
   <mvc:view-controller path="/" view-name="index" />
   <mvc:view-controller path="landing" view-name="index" />
   <mvc:view-controller path="/results" view-name="index" />
-  <mvc:view-controller path="/results/no-mast" view-name="index" />
+  <mvc:view-controller path="/results-no-mast" view-name="index" />
   <mvc:view-controller path="/insights" view-name="index" />
   <mvc:view-controller path="/doc360" view-name="index" />
   <mvc:view-controller path="login" view-name="index" />

--- a/servlet/application.properties
+++ b/servlet/application.properties
@@ -95,7 +95,7 @@ suit.attivio.password=attivio
 # or the main HTML file. Generally, the list of routes here should match the
 # routes defined in your application's main component (e.g. SearchUIApp.js in the
 # out-of-the-box version). It is a comma-separated list (with no spaces).
-suit.attivio.routes=/,/landing,/results,/insights,/doc360,/login,/error
+suit.attivio.routes=/,/landing,/results,/results/no-mast,/insights,/doc360,/login,/error
 
 # This is the location of the configuration.properties.js file that controls your
 # Search UI application. It should just be a file path (use forward slashes even

--- a/servlet/application.properties
+++ b/servlet/application.properties
@@ -95,7 +95,7 @@ suit.attivio.password=attivio
 # or the main HTML file. Generally, the list of routes here should match the
 # routes defined in your application's main component (e.g. SearchUIApp.js in the
 # out-of-the-box version). It is a comma-separated list (with no spaces).
-suit.attivio.routes=/,/landing,/results,/results/no-mast,/insights,/doc360,/login,/error
+suit.attivio.routes=/,/landing,/results,/results-no-mast,/insights,/doc360,/login,/error
 
 # This is the location of the configuration.properties.js file that controls your
 # Search UI application. It should just be a file path (use forward slashes even

--- a/servlet/src/main/java/com/attivio/suitback/controllers/HomeControllerHandlerMapper.java
+++ b/servlet/src/main/java/com/attivio/suitback/controllers/HomeControllerHandlerMapper.java
@@ -1,10 +1,7 @@
-/**
-* Copyright 2018 Attivio Inc., All rights reserved.
-*/
+/** Copyright 2018 Attivio Inc., All rights reserved. */
 package com.attivio.suitback.controllers;
 
 import javax.servlet.http.HttpServletRequest;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -16,13 +13,24 @@ public class HomeControllerHandlerMapper extends AbstractHandlerMapping {
   // to the application.properties to get logging (e.g., with value of TRACE).
   static final Logger LOG = LoggerFactory.getLogger(HomeControllerHandlerMapper.class);
 
-  static final String[] DEFAULT_ROUTES = new String[] {"/", "/login", "/loggededout", "/error", "/landing", "/results", "/insights", "/doc360"};
+  static final String[] DEFAULT_ROUTES =
+      new String[] {
+        "/",
+        "/login",
+        "/loggededout",
+        "/error",
+        "/landing",
+        "/results",
+        "/results/no-mast",
+        "/insights",
+        "/doc360"
+      };
 
   @Value("${suit.attivio.routes:}")
   String[] routes;
-  
+
   HomeController homeController;
-  
+
   public HomeControllerHandlerMapper(HomeController homeController) {
     this.homeController = homeController;
   }

--- a/servlet/src/main/java/com/attivio/suitback/controllers/HomeControllerHandlerMapper.java
+++ b/servlet/src/main/java/com/attivio/suitback/controllers/HomeControllerHandlerMapper.java
@@ -21,7 +21,7 @@ public class HomeControllerHandlerMapper extends AbstractHandlerMapping {
         "/error",
         "/landing",
         "/results",
-        "/results/no-mast",
+        "/results-no-mast",
         "/insights",
         "/doc360"
       };


### PR DESCRIPTION
Addresses [PLAT-44338](https://jira.attivio.com/browse/PLAT-44338)

Renders `<SearchBar />` on it's own instead of `<Masthead />` when the url contains `no-mast`.

This can be seen at http://acevm-57-166.lab.attivio.com:17000/beta/.

There is an [additional PR for PLAT-44338 targeting platform to support this change](https://git.attivio.com/attivio/platform/pull/458).

**Update**
There is an [additional PR for suit](https://github.com/attivio/suit/pull/168) to add support for the `show360` prop.