### PR TITLE
Feature/plat-41191

### DIFF
--- a/frontend/configuration.properties.js
+++ b/frontend/configuration.properties.js
@@ -16,7 +16,7 @@
 
     // This is the base URI that will be used for making REST API calls to the
     // Attivio server. When running as a module within the Attivio node, this should
-    // be the empty string (''). When running in the servlet, it should match the 
+    // be the empty string (''). When running in the servlet, it should match the
     // baseName property where the servlet is running relative to the machine (without
     // the hostname or port).
 
@@ -243,7 +243,7 @@
     // Whether signal needs to be generated when autocomplete item is selected
     createAutoCompleteSignal: true,
   },
-  
+
   // These properties configure the default properties for FacetSearchBar components in the UI.
   // These allow searching among all values of a specific facet, as well as being able to export
   // the list of all values for that facet to a CSV file.

--- a/frontend/configuration.properties.js
+++ b/frontend/configuration.properties.js
@@ -391,6 +391,10 @@
       'socialsecurity',
       'zipcode',
     ],
+    /** List of profiles from which users can select a query to be executed with */
+    profiles: [],
+    /** List of query workflows for which a user can choose to have process their query */
+    searchWorkflows: [],
   },
 
   // These properties configure the SearchUIInsightsPage, which displays facet information

--- a/frontend/src/pages/SearchUISearchPage.js
+++ b/frontend/src/pages/SearchUISearchPage.js
@@ -12,6 +12,8 @@ import {
   FacetResults,
   Masthead,
   MastheadNavTabs,
+  NavbarProfileSelector,
+  NavbarWorkflowSelector,
   NavbarSort,
   PlacementResults,
   SearchBar,
@@ -101,6 +103,10 @@ type SearchUISearchPageProps = {
    * location object injected by withRouter.
    */
   location: {};
+  /** List of profiles to populate the profile dropdown with */
+  profiles: Array<string>;
+  /** List of workflows to use for executing the query */
+  searchWorkflows: Array<string>;
 };
 
 /**
@@ -136,6 +142,8 @@ class SearchUISearchPage extends React.Component<SearchUISearchPageProps, Search
     maxFacetBuckets: 15,
     orderHint: [],
     entityColors: new Map(),
+    profiles: [],
+    searchWorkflows: [],
   };
 
   static contextTypes = {
@@ -155,7 +163,15 @@ class SearchUISearchPage extends React.Component<SearchUISearchPageProps, Search
       baseUri,
       relevancyModels,
       sortableFields,
+      profiles,
+      searchWorkflows,
     } = this.props;
+
+    const profileSelectorComp = profiles && profiles.length > 0 ?
+      <NavbarProfileSelector right profiles={profiles} /> : null;
+
+    const workflowSelectorComp = searchWorkflows && searchWorkflows.length > 0 ?
+      <NavbarWorkflowSelector right workflows={searchWorkflows} /> : null;
 
     return (
       <SecondaryNavBar>
@@ -163,6 +179,8 @@ class SearchUISearchPage extends React.Component<SearchUISearchPageProps, Search
         {hideMasthead && <SearchBar />}
         <SearchResultsFacetFilters />
         <SearchResultsPager right />
+        {profileSelectorComp}
+        {workflowSelectorComp}
         <SearchRelevancyModel
           right
           baseUri={baseUri}


### PR DESCRIPTION
Adding `NavbarWorkflowSelector` and `NavbarProfileSelector` to SearchUISearchPage so they can be enabled through the configuration.properties file. They are disabled by default. 